### PR TITLE
Fix code scanning alert no. 13: Server-side request forgery

### DIFF
--- a/webgoat-lessons/ssrf/src/main/java/org/owasp/webgoat/ssrf/SSRFTask2.java
+++ b/webgoat-lessons/ssrf/src/main/java/org/owasp/webgoat/ssrf/SSRFTask2.java
@@ -50,7 +50,7 @@ public class SSRFTask2 extends AssignmentEndpoint {
         try {
             StringBuffer html = new StringBuffer();
 
-            if (url.matches("http://ifconfig.pro")) {
+            if ("http://ifconfig.pro".equals(url)) {
                 URL u = new URL(url);
                 URLConnection urlConnection = u.openConnection();
                 BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));


### PR DESCRIPTION
Fixes [https://github.com/nekoaru/demo-vulnerabilities-ghas/security/code-scanning/13](https://github.com/nekoaru/demo-vulnerabilities-ghas/security/code-scanning/13)

To fix the problem, we need to ensure that the user-provided URL is strictly validated against a list of authorized URLs or restricted to a particular host or URL prefix. In this case, we can improve the validation by using a more robust method to check that the URL exactly matches the allowed value and does not contain any additional or manipulated parts.

1. Replace the current validation check with a more robust validation method.
2. Ensure that the URL is strictly validated against the allowed value "http://ifconfig.pro".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
